### PR TITLE
socket::socketOption() bool fix

### DIFF
--- a/socks.cpp
+++ b/socks.cpp
@@ -391,8 +391,8 @@ namespace sks {
 	}
 	
 	void socket::socketOption(boolOption option, bool value, optionLevel level) {
-		// Note: Passing the sizeof(bool) as the last parameter causes a throw
-		int e = setsockopt(m_sockFD, level, option, (const char*)&value, sizeof((int)value));
+		int boolConv = value;
+		int e = setsockopt(m_sockFD, level, option, (const char*)&boolConv, sizeof(boolConv));
 		if (e == -1) {
 			throw sysErr(errno);
 		}

--- a/socks.cpp
+++ b/socks.cpp
@@ -391,8 +391,8 @@ namespace sks {
 	}
 	
 	void socket::socketOption(boolOption option, bool value, optionLevel level) {
-		int boolConv = value;
-		int e = setsockopt(m_sockFD, level, option, (const char*)&boolConv, sizeof(boolConv));
+		// Note: Passing the sizeof(bool) as the last parameter causes a throw
+		int e = setsockopt(m_sockFD, level, option, (const char*)&value, sizeof((int)value));
 		if (e == -1) {
 			throw sysErr(errno);
 		}

--- a/socks.cpp
+++ b/socks.cpp
@@ -391,7 +391,8 @@ namespace sks {
 	}
 	
 	void socket::socketOption(boolOption option, bool value, optionLevel level) {
-		int e = setsockopt(m_sockFD, level, option, (const char*)&value, sizeof(value));
+		int boolConv = value;
+		int e = setsockopt(m_sockFD, level, option, (const char*)&boolConv, sizeof(boolConv));
 		if (e == -1) {
 			throw sysErr(errno);
 		}


### PR DESCRIPTION
setsockopt wouldn't accept a bool as a parameter, so we just convert it to an int
before using it.