### PR TITLE
Bugfix: Switch break to continue in echo_serv main.cpp

### DIFF
--- a/examples/echo_serv/main.cpp
+++ b/examples/echo_serv/main.cpp
@@ -77,7 +77,7 @@ int main()
                     {
                         std::cout << cIP << " has disconnected" << std::endl;
                         clientList.erase(std::remove(clientList.begin(), clientList.end(), l), clientList.end());
-                        break;
+                        continue;
                     }
 
                     std::cout << cIP << "> " << std::string(bytes.begin(), bytes.end()) << std::endl;


### PR DESCRIPTION
Foreach loop would terminate early on a single dead socket, we don't want that.

Thanks for pointing that out!